### PR TITLE
Booleans can't be compared

### DIFF
--- a/lib/ruboty.rb
+++ b/lib/ruboty.rb
@@ -25,7 +25,7 @@ module Ruboty
     memoize :handlers
 
     def actions
-      handlers.map(&:actions).flatten.sort_by(&:all?)
+      handlers.map(&:actions).flatten.sort_by { |action| action.all? ? 1 : 0 }
     end
   end
 end


### PR DESCRIPTION
```
>> [true,false].sort ArgumentError: comparison of TrueClass with false failed
>> [false,false].sort
=> [false,false]
```
