### PR TITLE
Fix typo in the spec file

### DIFF
--- a/spec/ruboty/adapters/shell_spec.rb
+++ b/spec/ruboty/adapters/shell_spec.rb
@@ -24,7 +24,7 @@ describe Ruboty::Adapters::Shell do
 
     context "with `quit`" do
       it "stops" do
-        Readline.stub(readline: "exit")
+        Readline.stub(readline: "quit")
         adapter.should_receive(:stop).and_call_original
         adapter.run
       end


### PR DESCRIPTION
Very minor one, but as just noticed while reading the code (It was great to read the well structured code!).