### PR TITLE
Remove warnings

### DIFF
--- a/lib/ruboty/commands/generate.rb
+++ b/lib/ruboty/commands/generate.rb
@@ -26,7 +26,7 @@ module Ruboty
       end
 
       def valid?
-        !File.exists?(destination_path)
+        !File.exist?(destination_path)
       end
     end
   end

--- a/lib/ruboty/handlers/help.rb
+++ b/lib/ruboty/handlers/help.rb
@@ -1,7 +1,7 @@
 module Ruboty
   module Handlers
     class Help < Base
-      on /help( me)?\z/i, name: "help", description: "Show this help message"
+      on(/help( me)?\z/i, name: "help", description: "Show this help message")
 
       def help(message)
         Ruboty::Actions::Help.new(message).call

--- a/lib/ruboty/handlers/ping.rb
+++ b/lib/ruboty/handlers/ping.rb
@@ -1,7 +1,7 @@
 module Ruboty
   module Handlers
     class Ping < Base
-      on /ping\z/i, name: "ping", description: "Return PONG to PING"
+      on(/ping\z/i, name: "ping", description: "Return PONG to PING")
 
       def ping(message)
         Ruboty::Actions::Ping.new(message).call

--- a/lib/ruboty/robot.rb
+++ b/lib/ruboty/robot.rb
@@ -32,6 +32,7 @@ module Ruboty
     end
 
     # @return [true] Because it needs to tell that an action is matched.
+    undef :say
     def say(*args)
       adapter.say(*args)
       true
@@ -77,7 +78,7 @@ module Ruboty
     end
 
     def handlers
-      Ruboty.handlers.map {|handler_class| handler_class.new(self) }
+      Ruboty.handlers.map { |handler_class| handler_class.new(self) }
     end
     memoize :handlers
 

--- a/spec/ruboty/commands/generate_spec.rb
+++ b/spec/ruboty/commands/generate_spec.rb
@@ -21,7 +21,7 @@ describe Ruboty::Commands::Generate do
     context "with normal condition" do
       it "generates ./ruboty/ directory from our templates" do
         call
-        File.exists?("./ruboty/").should == true
+        File.exist?("./ruboty/").should == true
       end
     end
 


### PR DESCRIPTION
/Users/trsw/github/ruboty/lib/ruboty/handlers/help.rb:4: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/trsw/github/ruboty/lib/ruboty/handlers/ping.rb:4: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/trsw/github/ruboty/lib/ruboty/robot.rb:35: warning: method redefined; discarding old say
/Users/trsw/github/ruboty/lib/ruboty/robot.rb:8: warning: previous definition of say was here

/Users/trsw/github/ruboty/lib/ruboty/commands/generate.rb:29: warning: File.exists? is a deprecated name, use File.exist? instead
/Users/trsw/github/ruboty/spec/ruboty/commands/generate_spec.rb:24: warning: File.exists? is a deprecated name, use File.exist? instead
./Users/trsw/github/ruboty/lib/ruboty/commands/generate.rb:29: warning: File.exists? is a deprecated name, use File.exist? instead
