### PR TITLE
compatibility with pry

### DIFF
--- a/lib/ruboty/command_builder.rb
+++ b/lib/ruboty/command_builder.rb
@@ -30,7 +30,7 @@ module Ruboty
         options.on("--dotenv", "Load .env before running.")
         options.on("-g", "--generate", "Generate a new chatterbot with ./ruboty/ directory if specified.")
         options.on("-h", "--help", "Display this help message.")
-        options.string("-l", "--load", "Load a ruby file before running.")
+        options.on("-l", "--load=", "Load a ruby file before running.")
       end
     end
     memoize :options

--- a/ruboty.gemspec
+++ b/ruboty.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler"
   spec.add_dependency "dotenv"
   spec.add_dependency "mem"
-  spec.add_dependency "slop", ">= 4.0.0"
+  spec.add_dependency "slop"
   spec.add_development_dependency "codeclimate-test-reporter", ">= 0.3.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "2.14.1"

--- a/ruboty.gemspec
+++ b/ruboty.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler"
   spec.add_dependency "dotenv"
   spec.add_dependency "mem"
-  spec.add_dependency "slop"
+  spec.add_dependency "slop", '~> 3'
   spec.add_development_dependency "codeclimate-test-reporter", ">= 0.3.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "2.14.1"


### PR DESCRIPTION
I update slop v3 to v4, (https://github.com/r7kamura/ruboty/pull/13, tttps://github.com/r7kamura/ruboty/commit/97bd9b211107bbfa821205c7305f5da3eb474a96)

but pry use slop v3, so if use slop v4 in ruboty, conflict or raise error like below.
```
/usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/dependency.rb:298:in `to_specs': Could not find 'gist' (>= 0) among 27 total gem(s) (Gem::LoadError)
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/dependency.rb:309:in `to_spec'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/specification.rb:907:in `find_by_name'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/command_base_helpers.rb:9:in `gem_installed?'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/command_base_helpers.rb:15:in `block in command_dependencies_met?'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/command_base_helpers.rb:14:in `each'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/command_base_helpers.rb:14:in `all?'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/command_base_helpers.rb:14:in `command_dependencies_met?'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/command_base.rb:53:in `command'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/commands.rb:195:in `<class:Commands>'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/commands.rb:12:in `<class:Pry>'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry/commands.rb:9:in `<top (required)>'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry.rb:23:in `require'
	from /usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.8.3/lib/pry.rb:23:in `<top (required)>'
```
And pry difficult to update to slop v4 (https://github.com/pry/pry/issues/1338)

Then I think to use slop 3.x is better way for now.(and sorry for my pllrequest(https://github.com/r7kamura/ruboty/pull/13))