### PR TITLE
Let shell adapter terminate when user inputs ^D

### DIFF
--- a/lib/ruboty/adapters/shell.rb
+++ b/lib/ruboty/adapters/shell.rb
@@ -45,7 +45,7 @@ module Ruboty
 
       def step
         case body = read
-        when "exit", "quit"
+        when "exit", "quit", nil
           stop
         else
           robot.receive(body: body, source: SOURCE)

--- a/spec/ruboty/adapters/shell_spec.rb
+++ b/spec/ruboty/adapters/shell_spec.rb
@@ -30,6 +30,14 @@ describe Ruboty::Adapters::Shell do
       end
     end
 
+    context "with EOF" do
+      it "stops" do
+        Readline.stub(readline: nil)
+        adapter.should_receive(:stop).and_call_original
+        adapter.run
+      end
+    end
+
     context "with Inturrupt from console" do
       it "stops" do
         Readline.stub(:readline).and_raise(Interrupt)


### PR DESCRIPTION
When user inputs EOF on ruboty shell, it should be terminated.
Ruby `Readline` library returns `nil` on receiving EOF, so the simplest code should be like this.