### PR TITLE
Add "command" option to handlers to make help messages easy to read

### DIFF
--- a/lib/ruboty/action.rb
+++ b/lib/ruboty/action.rb
@@ -40,6 +40,10 @@ module Ruboty
       options[:name]
     end
 
+    def command
+      options[:command]
+    end
+
     def <=>(action)
       pattern.to_s <=> action.pattern.to_s
     end

--- a/lib/ruboty/actions/help.rb
+++ b/lib/ruboty/actions/help.rb
@@ -21,7 +21,7 @@ module Ruboty
         _descriptions = Ruboty.actions.reject(&:hidden?).sort.map do |action|
           prefix = ""
           prefix << message.robot.name << " " unless  action.all?
-          "#{prefix}#{action.pattern.inspect} - #{action.description}"
+          "#{prefix}#{action.command || action.pattern.inspect} - #{action.description}"
         end
       end
     end

--- a/lib/ruboty/handlers/help.rb
+++ b/lib/ruboty/handlers/help.rb
@@ -5,6 +5,7 @@ module Ruboty
         /help( me)?(?: (?<filter>.+))?\z/i,
         description: "Show this help message",
         name: "help",
+        command: "help (me) (<filter>)",
       )
 
       def help(message)

--- a/lib/ruboty/handlers/ping.rb
+++ b/lib/ruboty/handlers/ping.rb
@@ -1,7 +1,7 @@
 module Ruboty
   module Handlers
     class Ping < Base
-      on(/ping\z/i, name: "ping", description: "Return PONG to PING")
+      on(/ping\z/i, name: "ping", description: "Return PONG to PING", command: "ping")
 
       def ping(message)
         Ruboty::Actions::Ping.new(message).call

--- a/lib/ruboty/handlers/whoami.rb
+++ b/lib/ruboty/handlers/whoami.rb
@@ -5,6 +5,7 @@ module Ruboty
         /who am i\?/i,
         name: "whoami",
         description: "Answer who you are",
+        command: "who am i?",
       )
 
       def whoami(message)

--- a/spec/ruboty/handlers/help_spec.rb
+++ b/spec/ruboty/handlers/help_spec.rb
@@ -17,9 +17,9 @@ describe Ruboty::Handlers::Help do
     context "with valid condition" do
       let(:body) do
         <<-EOS.strip_heredoc.strip
-          ruboty /help( me)?(?: (?<filter>.+))?\\z/i - Show this help message
-          ruboty /ping\\z/i - Return PONG to PING
-          ruboty /who am i\\?/i - Answer who you are
+          ruboty help (me) (<filter>) - Show this help message
+          ruboty ping - Return PONG to PING
+          ruboty who am i? - Answer who you are
         EOS
       end
 
@@ -44,7 +44,7 @@ describe Ruboty::Handlers::Help do
       it "filters descriptions by given filter" do
         robot.should_receive(:say).with(
           hash_including(
-            body: "ruboty /ping\\z/i - Return PONG to PING",
+            body: "ruboty ping - Return PONG to PING",
           ),
         )
         robot.receive(body: "@ruboty help ping", from: from, to: to)


### PR DESCRIPTION
Showing exact matching patterns in help messages is clear and convenient, but they seem to be too hard to understand especially to non-developers who are not familiar with regular expressions. e.g.:

``` text
ruboty /help( me)?(?: (?<filter>.+))?\\z/i - Show this help message
```

While in Hubot you can specify the help message in addition to the pattern itself, you can't set it in Ruboty handlers, so I have added `command` option. Now `ruboty help` shows more easy-to-read messages only when `command` option is provided, like:

``` text
ruboty help (me) (<filter>) - Show this help message
```
