### PR TITLE
Bundle update rspec

### DIFF
--- a/ruboty.gemspec
+++ b/ruboty.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "slop"
   spec.add_development_dependency "codeclimate-test-reporter", ">= 0.3.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "2.14.1"
+  spec.add_development_dependency "rspec", "3.4.0"
   spec.add_development_dependency "simplecov"
 end

--- a/spec/ruboty/adapter_builder_spec.rb
+++ b/spec/ruboty/adapter_builder_spec.rb
@@ -12,7 +12,7 @@ describe Ruboty::AdapterBuilder do
   describe "#build" do
     context "with no other adapter class definition" do
       it "returns a Ruboty::Adapters::Shell as a default adapter" do
-        builder.build.should be_a Ruboty::Adapters::Shell
+        expect(builder.build).to be_a Ruboty::Adapters::Shell
       end
     end
 
@@ -29,7 +29,7 @@ describe Ruboty::AdapterBuilder do
       end
 
       it "returns an instance of that adapter class" do
-        builder.build.should be_a another_adapter_class
+        expect(builder.build).to be_a another_adapter_class
       end
     end
   end

--- a/spec/ruboty/adapters/shell_spec.rb
+++ b/spec/ruboty/adapters/shell_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Ruboty::Adapters::Shell do
   before do
-    Ruboty.logger.stub(:info)
+    allow(Ruboty.logger).to receive(:info)
   end
 
   let(:adapter) do
@@ -16,40 +16,40 @@ describe Ruboty::Adapters::Shell do
   describe "#run" do
     context "with `exit`" do
       it "stops" do
-        Readline.stub(readline: "exit")
-        adapter.should_receive(:stop).and_call_original
+        allow(Readline).to receive(:readline).and_return("exit")
+        expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
     end
 
     context "with `quit`" do
       it "stops" do
-        Readline.stub(readline: "quit")
-        adapter.should_receive(:stop).and_call_original
+        allow(Readline).to receive(:readline).and_return("quit")
+        expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
     end
 
     context "with EOF" do
       it "stops" do
-        Readline.stub(readline: nil)
-        adapter.should_receive(:stop).and_call_original
+        allow(Readline).to receive(:readline).and_return(nil)
+        expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
     end
 
     context "with Inturrupt from console" do
       it "stops" do
-        Readline.stub(:readline).and_raise(Interrupt)
-        adapter.should_receive(:stop).and_call_original
+        allow(Readline).to receive(:readline).and_raise(Interrupt)
+        expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
     end
 
     context "without `exit` nor `quit`" do
       it "passes given message to robot" do
-        Readline.stub(:readline).and_return("a", "exit")
-        robot.should_receive(:receive).with(body: "a", source: described_class::SOURCE)
+        allow(Readline).to receive(:readline).and_return("a", "exit")
+        expect(robot).to receive(:receive).with(body: "a", source: described_class::SOURCE)
         adapter.run
       end
     end

--- a/spec/ruboty/commands/generate_spec.rb
+++ b/spec/ruboty/commands/generate_spec.rb
@@ -21,7 +21,7 @@ describe Ruboty::Commands::Generate do
     context "with normal condition" do
       it "generates ./ruboty/ directory from our templates" do
         call
-        File.exist?("./ruboty/").should == true
+        expect(File).to be_exist("./ruboty/")
       end
     end
 
@@ -31,7 +31,7 @@ describe Ruboty::Commands::Generate do
       end
 
       it "exits process with dying message" do
-        Ruboty.logger.should_receive(:error).with("Error: ./ruboty/ already exists.")
+        expect(Ruboty.logger).to receive(:error).with("Error: ./ruboty/ already exists.")
         expect { call }.to raise_error(SystemExit)
       end
     end

--- a/spec/ruboty/commands/run_spec.rb
+++ b/spec/ruboty/commands/run_spec.rb
@@ -15,7 +15,7 @@ describe Ruboty::Commands::Run do
     end
 
     it "creates an adapter and calls .run to it" do
-      Ruboty::Adapters::Shell.any_instance.should_receive(:run)
+      expect_any_instance_of(Ruboty::Adapters::Shell).to receive(:run)
       call
     end
   end

--- a/spec/ruboty/env/validatable_spec.rb
+++ b/spec/ruboty/env/validatable_spec.rb
@@ -39,8 +39,8 @@ describe Ruboty::Env::Validatable do
   describe "#validate!" do
     context "without required ENV" do
       it "dies with usage as erorr message" do
-        Ruboty.logger.should_receive(:error).with(/description of A/)
-        Ruboty.should_receive(:exit)
+        expect(Ruboty.logger).to receive(:error).with(/description of A/)
+        expect(Ruboty).to receive(:exit)
         instance.validate!
       end
     end

--- a/spec/ruboty/handlers/base_spec.rb
+++ b/spec/ruboty/handlers/base_spec.rb
@@ -21,7 +21,7 @@ describe Ruboty::Handlers::Base do
 
   describe ".on" do
     it "registers an action to the handler" do
-      robot.should_receive(:say).with(2)
+      expect(robot).to receive(:say).with(2)
       robot.receive(body: "1 + 1")
     end
   end

--- a/spec/ruboty/handlers/help_spec.rb
+++ b/spec/ruboty/handlers/help_spec.rb
@@ -24,7 +24,7 @@ describe Ruboty::Handlers::Help do
       end
 
       it "responds to `@ruboty help` and says each handler's description" do
-        robot.should_receive(:say).with(
+        expect(robot).to receive(:say).with(
           body: body,
           code: true,
           from: to,
@@ -42,7 +42,7 @@ describe Ruboty::Handlers::Help do
 
     context "with filter" do
       it "filters descriptions by given filter" do
-        robot.should_receive(:say).with(
+        expect(robot).to receive(:say).with(
           hash_including(
             body: "ruboty /ping\\z/i - Return PONG to PING",
           ),

--- a/spec/ruboty/handlers/ping_spec.rb
+++ b/spec/ruboty/handlers/ping_spec.rb
@@ -23,7 +23,7 @@ describe Ruboty::Handlers::Ping do
     end
 
     it "returns PONG to PING" do
-      robot.should_receive(:say).with(
+      expect(robot).to receive(:say).with(
         body: replied,
         from: to,
         to: from,

--- a/spec/ruboty/handlers/whoami_spec.rb
+++ b/spec/ruboty/handlers/whoami_spec.rb
@@ -19,7 +19,7 @@ describe Ruboty::Handlers::Whoami do
     end
 
     it "returns PONG to PING" do
-      robot.should_receive(:say).with(
+      expect(robot).to receive(:say).with(
         body: from,
         from: to,
         to: from,

--- a/spec/ruboty/robot_spec.rb
+++ b/spec/ruboty/robot_spec.rb
@@ -12,12 +12,12 @@ describe Ruboty::Robot do
   describe "#brain" do
     context "without any Brain class" do
       it "returns a Ruboty::Brains::Memory" do
-        instance.brain.should be_a Ruboty::Brains::Memory
+        expect(instance.brain).to be_a Ruboty::Brains::Memory
       end
 
       it "can be used as a Hash object" do
         instance.brain.data["a"] = 1
-        instance.brain.data["a"].should == 1
+        expect(instance.brain.data["a"]).to eq 1
       end
     end
 
@@ -31,7 +31,7 @@ describe Ruboty::Robot do
       end
 
       it "returns its instance as a Brain" do
-        instance.brain.should be_a another_brain_class
+        expect(instance.brain).to be_a another_brain_class
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require "active_support/core_ext/string/strip"
 require "ruboty"
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end


### PR DESCRIPTION
To avoid the following deprecated warning, I did `bundle update rspec`.

```
[DEPRECATION] last_comment is deprecated. Please use last_description instead.
```