### PR TITLE
Respond with error message when no description matched

### DIFF
--- a/lib/ruboty/actions/help.rb
+++ b/lib/ruboty/actions/help.rb
@@ -2,19 +2,24 @@ module Ruboty
   module Actions
     class Help < Base
       def call
-        message.reply(body, code: true)
+        descriptions = filtered_descriptions
+        if descriptions.empty?
+          message.reply("No description matched to '#{message[:filter]}'")
+        else
+          message.reply(descriptions.join("\n"), code: true)
+        end
       end
 
       private
 
-      def body
+      def filtered_descriptions
         descriptions = all_descriptions
         if message[:filter]
           descriptions.select! do |description|
             description.include?(message[:filter])
           end
         end
-        descriptions.join("\n")
+        descriptions
       end
 
       def all_descriptions


### PR DESCRIPTION
![a](https://cloud.githubusercontent.com/assets/3138447/14878273/7e39f60e-0d5d-11e6-8e46-ce487326faa2.png)

The image is a response to `ruboty help [filter]` when filter matches no description. Some of my colleagues told me that it is a bug (of course it is not). Thus I want to show error message when no description is matched by `ruboty help [filter]`.