### PR TITLE
Add --pid option to write PID file

### DIFF
--- a/lib/ruboty/command_builder.rb
+++ b/lib/ruboty/command_builder.rb
@@ -32,8 +32,10 @@ module Ruboty
         options.on("-h", "--help", "Display this help message.")
         if Slop::VERSION >= "4.0.0"
           options.string("-l", "--load", "Load a ruby file before running.")
+          options.string("--pid", "Write the PID to a file.")
         else
           options.on("-l", "--load=", "Load a ruby file before running.")
+          options.on("--pid=", "Write the PID to a file.")
         end
       end
     end

--- a/lib/ruboty/robot.rb
+++ b/lib/ruboty/robot.rb
@@ -17,6 +17,7 @@ module Ruboty
       dotenv
       bundle
       setup
+      pid
       remember
       handle
       adapt
@@ -88,6 +89,14 @@ module Ruboty
 
     def handle
       handlers
+    end
+
+    def pid
+      path = options[:pid]
+      if path
+        File.open(path, "w") { |f| f.write(Process.pid) }
+        at_exit { File.unlink(path) }
+      end
     end
   end
 end


### PR DESCRIPTION
Starting ruboty with `--pid <path>` option, it writes the PID to a file at the path, and removes it when ruboty shutdowns.