### PR TITLE
Add --daemon option to daemonize

### DIFF
--- a/lib/ruboty/command_builder.rb
+++ b/lib/ruboty/command_builder.rb
@@ -27,6 +27,7 @@ module Ruboty
 
     def options
       Slop.parse(arguments) do |options|
+        options.on("--daemon", "Run as a daemon.")
         options.on("--dotenv", "Load .env before running.")
         options.on("-g", "--generate", "Generate a new chatterbot with ./ruboty/ directory if specified.")
         options.on("-h", "--help", "Display this help message.")

--- a/lib/ruboty/robot.rb
+++ b/lib/ruboty/robot.rb
@@ -14,6 +14,7 @@ module Ruboty
     end
 
     def run
+      daemon
       dotenv
       bundle
       setup
@@ -68,6 +69,10 @@ module Ruboty
       ENV["RUBOTY_ENV"] || DEFAULT_ENV
     end
     memoize :env
+
+    def daemon
+      Process.daemon(true, false) if options[:daemon]
+    end
 
     def dotenv
       Dotenv.load if options[:dotenv]


### PR DESCRIPTION
Starting ruboty with `--daemon` option, it runs as a daemon.