### PR TITLE
Improve readability of help handler

### DIFF
--- a/lib/ruboty/action.rb
+++ b/lib/ruboty/action.rb
@@ -23,6 +23,10 @@ module Ruboty
       !!options[:all]
     end
 
+    def command
+      options[:command] || pattern.inspect
+    end
+
     def description
       options[:description] || "(no description)"
     end

--- a/lib/ruboty/actions/help.rb
+++ b/lib/ruboty/actions/help.rb
@@ -26,7 +26,7 @@ module Ruboty
         _descriptions = Ruboty.actions.reject(&:hidden?).sort.map do |action|
           prefix = ""
           prefix << message.robot.name << " " unless  action.all?
-          "#{prefix}#{action.pattern.inspect} - #{action.description}"
+          "#{prefix}#{action.command} - #{action.description}"
         end
       end
     end

--- a/lib/ruboty/handlers/help.rb
+++ b/lib/ruboty/handlers/help.rb
@@ -3,8 +3,9 @@ module Ruboty
     class Help < Base
       on(
         /help( me)?(?: (?<filter>.+))?\z/i,
-        description: "Show this help message",
         name: "help",
+        command: "help [me] [<filter>]",
+        description: "Show this help message",
       )
 
       def help(message)

--- a/lib/ruboty/handlers/ping.rb
+++ b/lib/ruboty/handlers/ping.rb
@@ -1,7 +1,12 @@
 module Ruboty
   module Handlers
     class Ping < Base
-      on(/ping\z/i, name: "ping", description: "Return PONG to PING")
+      on(
+        /ping\z/i,
+        name: "ping",
+        command: "ping",
+        description: "Return PONG to PING"
+      )
 
       def ping(message)
         Ruboty::Actions::Ping.new(message).call

--- a/lib/ruboty/handlers/whoami.rb
+++ b/lib/ruboty/handlers/whoami.rb
@@ -3,6 +3,7 @@ module Ruboty
     class Whoami < Base
       on(
         /who am i\?/i,
+        command: "who am i",
         name: "whoami",
         description: "Answer who you are",
       )

--- a/spec/ruboty/handlers/help_spec.rb
+++ b/spec/ruboty/handlers/help_spec.rb
@@ -17,9 +17,9 @@ describe Ruboty::Handlers::Help do
     context "with valid condition" do
       let(:body) do
         <<-EOS.strip_heredoc.strip
-          ruboty /help( me)?(?: (?<filter>.+))?\\z/i - Show this help message
-          ruboty /ping\\z/i - Return PONG to PING
-          ruboty /who am i\\?/i - Answer who you are
+          ruboty help [me] [<filter>] - Show this help message
+          ruboty ping - Return PONG to PING
+          ruboty who am i - Answer who you are
         EOS
       end
 
@@ -44,7 +44,7 @@ describe Ruboty::Handlers::Help do
       it "filters descriptions by given filter" do
         expect(robot).to receive(:say).with(
           hash_including(
-            body: "ruboty /ping\\z/i - Return PONG to PING",
+            body: "ruboty ping - Return PONG to PING",
           ),
         )
         robot.receive(body: "@ruboty help ping", from: from, to: to)


### PR DESCRIPTION
Before:
```
> ruboty help
ruboty /help( me)?(?: (?<filter>.+))?\z/i - Show this help message
ruboty /ping\z/i - Return PONG to PING
ruboty /who am i\?/i - Answer who you are
```
After:
```
> ruboty help
ruboty help [me] [<filter>] - Show this help message
ruboty ping - Return PONG to PING
ruboty who am i - Answer who you are
```