### PR TITLE
Support unicode spaces like U+00a0

### DIFF
--- a/lib/ruboty/action.rb
+++ b/lib/ruboty/action.rb
@@ -1,7 +1,7 @@
 module Ruboty
   class Action
     def self.prefix_pattern(robot_name)
-      /\A@?#{Regexp.escape(robot_name)}:?\s+/
+      /\A@?#{Regexp.escape(robot_name)}:?[[:space:]]+/
     end
 
     attr_reader :options, :pattern


### PR DESCRIPTION
On some platforms, spaces may be converted to Unicode spaces, and `\s+` is not matched with such Unicode spaces.

This patch just changes regex pattern from `\s` to `[[:space:]]`.

I confirmed that Slack on Mac OS X will convert `"  "` to `" \u{00a0}"` automatically on copy-and-past.