### PR TITLE
Use reline gem instead of readline

### DIFF
--- a/lib/ruboty/adapters/shell.rb
+++ b/lib/ruboty/adapters/shell.rb
@@ -1,4 +1,4 @@
-require "readline"
+require "reline"
 
 module Ruboty
   module Adapters
@@ -32,7 +32,7 @@ module Ruboty
       end
 
       def read
-        Readline.readline(PROMPT, true).tap do |line|
+        Reline.readline(PROMPT, true).tap do |line|
           history_file.puts(line)
         end
       end
@@ -63,7 +63,7 @@ module Ruboty
       def remember
         if history_pathname.exist?
           history_pathname.each_line do |line|
-            Readline::HISTORY << line.rstrip
+            Reline::HISTORY << line.rstrip
           end
         end
       end

--- a/ruboty.gemspec
+++ b/ruboty.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.2.2"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "activesupport"
   spec.add_dependency "bundler"

--- a/ruboty.gemspec
+++ b/ruboty.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler"
   spec.add_dependency "dotenv"
   spec.add_dependency "mem"
+  spec.add_dependency "reline"
   spec.add_dependency "slop"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "3.4.0"

--- a/spec/ruboty/adapters/shell_spec.rb
+++ b/spec/ruboty/adapters/shell_spec.rb
@@ -16,7 +16,7 @@ describe Ruboty::Adapters::Shell do
   describe "#run" do
     context "with `exit`" do
       it "stops" do
-        allow(Readline).to receive(:readline).and_return("exit")
+        allow(Reline).to receive(:readline).and_return("exit")
         expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
@@ -24,7 +24,7 @@ describe Ruboty::Adapters::Shell do
 
     context "with `quit`" do
       it "stops" do
-        allow(Readline).to receive(:readline).and_return("quit")
+        allow(Reline).to receive(:readline).and_return("quit")
         expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
@@ -32,7 +32,7 @@ describe Ruboty::Adapters::Shell do
 
     context "with EOF" do
       it "stops" do
-        allow(Readline).to receive(:readline).and_return(nil)
+        allow(Reline).to receive(:readline).and_return(nil)
         expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
@@ -40,7 +40,7 @@ describe Ruboty::Adapters::Shell do
 
     context "with Inturrupt from console" do
       it "stops" do
-        allow(Readline).to receive(:readline).and_raise(Interrupt)
+        allow(Reline).to receive(:readline).and_raise(Interrupt)
         expect(adapter).to receive(:stop).and_call_original
         adapter.run
       end
@@ -48,7 +48,7 @@ describe Ruboty::Adapters::Shell do
 
     context "without `exit` nor `quit`" do
       it "passes given message to robot" do
-        allow(Readline).to receive(:readline).and_return("a", "exit")
+        allow(Reline).to receive(:readline).and_return("a", "exit")
         expect(robot).to receive(:receive).with(body: "a", source: described_class::SOURCE)
         adapter.run
       end


### PR DESCRIPTION
## What

readline was removed from Ruby's default gems in 4.0.0, so depend on reline explicitly via the gemspec and switch the Shell adapter to the Reline API (Reline.readline / Reline::HISTORY).

## concern
`reline` requires Ruby >= 2.6, so merging this raises the minimum supported Ruby from 2.2.2 to 2.6, how do you think that @r7kamura ?